### PR TITLE
Add basic data processing utilities and tests

### DIFF
--- a/data_processing.py
+++ b/data_processing.py
@@ -1,0 +1,29 @@
+import csv
+from typing import List, Dict, Optional
+
+def load_sat_results(path: str) -> List[Dict[str, str]]:
+    """Load SAT results data from a CSV file.
+
+    Returns a list of rows where each row is a dict mapping column names to values."""
+    # ``utf-8-sig`` handles files that start with a UTF-8 BOM, which some of the
+    # project data files include.
+    with open(path, newline='', encoding='utf-8-sig') as f:
+        reader = csv.DictReader(f)
+        return list(reader)
+
+def add_total_score(rows: List[Dict[str, str]]) -> List[Dict[str, Optional[int]]]:
+    """Add a total SAT score to each row.
+
+    The total is the sum of the reading, math, and writing scores. Non-numeric values
+    result in a total of ``None``."""
+    for row in rows:
+        try:
+            total = (
+                int(row['SAT Critical Reading Avg. Score'])
+                + int(row['SAT Math Avg. Score'])
+                + int(row['SAT Writing Avg. Score'])
+            )
+        except (ValueError, KeyError):
+            total = None
+        row['sat_total'] = total
+    return rows

--- a/tests/test_data_processing.py
+++ b/tests/test_data_processing.py
@@ -1,0 +1,22 @@
+import sys
+from pathlib import Path
+
+# Ensure the repository root is on the import path
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from data_processing import load_sat_results, add_total_score
+
+
+def test_load_sat_results():
+    rows = load_sat_results('data/sat_results.csv')
+    assert len(rows) > 0
+    # First row should correspond to DBN 01M292
+    assert rows[0]['DBN'] == '01M292'
+
+
+def test_add_total_score():
+    rows = load_sat_results('data/sat_results.csv')
+    rows = add_total_score(rows)
+    # Find the row for DBN 01M292 and ensure total score is correct
+    row = next(r for r in rows if r['DBN'] == '01M292')
+    assert row['sat_total'] == 355 + 404 + 363


### PR DESCRIPTION
## Summary
- add utility functions for loading SAT results and computing total scores
- create pytest suite verifying data loading and score calculations

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68953c4e793c833086112d08a32dc2d0